### PR TITLE
Add nixBuildArgs parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,13 @@ jobs:
       with:
         name: cachix-action
         skipNixBuild: true
+    - name: Test nixBuildArgs parameter
+      uses: ./
+      with:
+        name: cachix-action
+        file: test-with-arg.nix
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        nixBuildArgs: --argstr arg foobar
     - name: Test private cache
       uses: ./
       with:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,8 @@ inputs:
     description: 'Nix file to build. Defaults to default.nix'
   attributes:
     description: 'Nix attributes to nix-build. By default, all attributes are built.'
+  nixBuildArgs:
+    description: 'Additional arguments for nix-build.'
 branding:
   color: 'blue'
   icon: 'database'

--- a/lib/main.js
+++ b/lib/main.js
@@ -35,6 +35,7 @@ function run() {
             const file = core.getInput('file');
             const skipNixBuild = core.getInput('skipNixBuild');
             const attributes = core.getInput('attributes');
+            const nixBuildArgs = core.getInput('nixBuildArgs');
             const name = core.getInput('name', { required: true });
             const signingKey = core.getInput('signingKey');
             const authToken = core.getInput('authToken');
@@ -84,7 +85,8 @@ function run() {
                     }
                 };
                 const args = strings_1.prependEach('-A', strings_1.nonEmptySplit(attributes, /\s+/)).concat([file || "default.nix"]);
-                yield exec.exec('nix-build', args, options);
+                const additionalArgs = strings_1.nonEmptySplit(nixBuildArgs, /\s+/);
+                yield exec.exec('nix-build', additionalArgs.concat(args), options);
                 core.endGroup();
             }
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
-import {type} from 'os';
-import {prependEach, nonEmptySplit} from './strings';
+import { type } from 'os';
+import { prependEach, nonEmptySplit } from './strings';
 
 function home() {
   if (type() == "Darwin") {
@@ -17,6 +17,7 @@ async function run() {
     const file = core.getInput('file');
     const skipNixBuild = core.getInput('skipNixBuild');
     const attributes = core.getInput('attributes');
+    const nixBuildArgs = core.getInput('nixBuildArgs');
     const name = core.getInput('name', { required: true });
     const signingKey = core.getInput('signingKey');
     const authToken = core.getInput('authToken')
@@ -71,13 +72,14 @@ async function run() {
         }
       };
       const args = prependEach('-A', nonEmptySplit(attributes, /\s+/)).concat([file || "default.nix"]);
-      await exec.exec('nix-build', args, options);
+      const additionalArgs = nonEmptySplit(nixBuildArgs, /\s+/);
+      await exec.exec('nix-build', additionalArgs.concat(args), options);
       core.endGroup()
     }
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);
-    throw(error);
-  } 
+    throw (error);
+  }
 }
 
 run();

--- a/test-with-arg.nix
+++ b/test-with-arg.nix
@@ -1,0 +1,10 @@
+{ arg ? null }:
+
+with import <nixpkgs> {};
+
+if arg == null
+then abort "arg is not set"
+else writeText "test-with-arg" ''
+  ${toString builtins.currentTime}
+  ${arg}
+''


### PR DESCRIPTION
Hey,

I added a new parameter for the action called `nixBuildArgs`. This adds arbitrary arguments to the `nix-build` command like for example `--keep-going`, `--show-trace` or `--argstr foo bar`.

Resolves https://github.com/cachix/cachix-action/issues/24 in a more general way.