### PR TITLE
Add extra caches for pulls/substitutions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
   name:
     description: 'Name of a cachix cache to push and pull/substitute'
     required: true
+  extraPullNames:
+    description: 'Comma-separated list of names for extra cachix caches to pull/substitute'
   authToken:
     description: 'Authentication token for Cachix, needed only for private cache access'
   signingKey:

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -977,6 +977,7 @@ const exec = __importStar(__webpack_require__(986));
 exports.IsPost = !!process.env['STATE_isPost'];
 // inputs
 const name = core.getInput('name', { required: true });
+const extraPullNames = core.getInput('extraPullNames');
 const signingKey = core.getInput('signingKey');
 const authToken = core.getInput('authToken');
 const skipPush = core.getInput('skipPush');
@@ -994,6 +995,15 @@ function setup() {
             core.startGroup(`Cachix: using cache ` + name);
             yield exec.exec('cachix', ['use', name]);
             core.endGroup();
+            if (extraPullNames != "") {
+                core.startGroup(`Cachix: using extra caches ` + extraPullNames);
+                const extraPullNameList = extraPullNames.split(',');
+                for (let itemName of extraPullNameList) {
+                    const trimmedItemName = itemName.trim();
+                    yield exec.exec('cachix', ['use', trimmedItemName]);
+                }
+                core.endGroup();
+            }
             if (signingKey !== "") {
                 core.exportVariable('CACHIX_SIGNING_KEY', signingKey);
                 // Remember existing store paths

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ export const IsPost = !!process.env['STATE_isPost']
 
 // inputs
 const name = core.getInput('name', { required: true });
+const extraPullNames = core.getInput('extraPullNames');
 const signingKey = core.getInput('signingKey');
 const authToken = core.getInput('authToken')
 const skipPush = core.getInput('skipPush');
@@ -26,6 +27,16 @@ async function setup() {
     core.startGroup(`Cachix: using cache ` + name);
     await exec.exec('cachix', ['use', name]);
     core.endGroup();
+
+    if (extraPullNames != "") {
+      core.startGroup(`Cachix: using extra caches ` + extraPullNames);
+      const extraPullNameList = extraPullNames.split(',');
+      for (let itemName of extraPullNameList) {
+        const trimmedItemName = itemName.trim();
+        await exec.exec('cachix', ['use', trimmedItemName]);
+      }
+      core.endGroup();
+    }
 
     if (signingKey !== "") {
       core.exportVariable('CACHIX_SIGNING_KEY', signingKey);


### PR DESCRIPTION
This is an attempted fix to add extra caches for pulling from (binary substitution). It adds an `extraPullNames` parameter, to mimic the existing `name` parameter. It considers the string to be a comma-separated set of caches.

Fixes #28 