### PR TITLE
add installCommand option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,21 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY_PRIVATE }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix-build test.nix
+
+  installCommand:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - run: yarn install --frozen-lockfile
+    - run: yarn build
+    - uses: cachix/install-nix-action@v10
+    - name: Test private cache
+      uses: ./
+      with:
+        name: cachix-action
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        installCommand: 'nix-env -f https://github.com/NixOS/nixpkgs/archive/master.tar.gz -iA cachix'
+    - run: nix-build test.nix

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,8 @@ inputs:
     description: 'Signing key secret retrieved after creating binary cache on https://cachix.org'
   skipPush:
     description: 'Set to true to disable pushing build results to the cache'
+  installCommand:
+    description: 'Override the default cachix installation method'
 branding:
   color: 'blue'
   icon: 'database'

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -982,11 +982,13 @@ const signingKey = core.getInput('signingKey');
 const authToken = core.getInput('authToken');
 const skipPush = core.getInput('skipPush');
 const cachixExecutable = '/nix/var/nix/profiles/per-user/runner/profile/bin/cachix';
+const installCommand = core.getInput('installCommand') ||
+    "nix-env --quiet -iA cachix -f https://cachix.org/api/v1/install";
 function setup() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.startGroup('Cachix: installing');
-            yield exec.exec('nix-env', ['--quiet', '-iA', 'cachix', '-f', 'https://cachix.org/api/v1/install']);
+            yield exec.exec('bash', ['-c', installCommand]);
             core.endGroup();
             // for private caches
             if (authToken !== "") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,11 +12,14 @@ const signingKey = core.getInput('signingKey');
 const authToken = core.getInput('authToken')
 const skipPush = core.getInput('skipPush');
 const cachixExecutable = '/nix/var/nix/profiles/per-user/runner/profile/bin/cachix';
+const installCommand =
+  core.getInput('installCommand') ||
+  "nix-env --quiet -iA cachix -f https://cachix.org/api/v1/install";
 
 async function setup() {
   try {
     core.startGroup('Cachix: installing')
-    await exec.exec('nix-env', ['--quiet', '-iA', 'cachix', '-f', 'https://cachix.org/api/v1/install']);
+    await exec.exec('bash', ['-c', installCommand]);
     core.endGroup()
 
     // for private caches


### PR DESCRIPTION
By using `installCommand`, it's possible to avoid yet another pull of
nixpkgs and speed-up the CI.

This means that users will potentially get stuck on older APIs so maybe I should add a check for the minimum cachix version as well?