### PR TITLE
clean error outputs

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -1080,7 +1080,7 @@ function setup() {
 }
 function upload() {
     return __awaiter(this, void 0, void 0, function* () {
-        core.startGroup('Cachix: upload');
+        core.startGroup('Cachix: push');
         try {
             if (skipPush === 'true') {
                 core.info('Pushing is disabled as skipPush is set to true');

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -1033,7 +1033,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(__webpack_require__(470));
-const child_process_1 = __webpack_require__(129);
 const coreCommand = __importStar(__webpack_require__(431));
 const exec = __importStar(__webpack_require__(986));
 exports.IsPost = !!process.env['STATE_isPost'];
@@ -1076,20 +1075,18 @@ function setup() {
         }
         catch (error) {
             core.setFailed(`Action failed with error: ${error}`);
-            throw (error);
         }
     });
 }
 function upload() {
     return __awaiter(this, void 0, void 0, function* () {
+        core.startGroup('Cachix: upload');
         try {
             if (skipPush === 'true') {
                 core.info('Pushing is disabled as skipPush is set to true');
             }
             else if (signingKey !== "" || authToken !== "") {
-                core.startGroup('Cachix: pushing paths');
-                child_process_1.execFileSync(`${__dirname}/push-paths.sh`, [cachixExecutable, name], { stdio: 'inherit' });
-                core.endGroup();
+                yield exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name]);
             }
             else {
                 core.info('Pushing is disabled as signing key nor auth token are set.');
@@ -1097,8 +1094,8 @@ function upload() {
         }
         catch (error) {
             core.setFailed(`Action failed with error: ${error}`);
-            throw (error);
         }
+        core.endGroup();
     });
 }
 // Main

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ async function setup() {
 }
 
 async function upload() {
-  core.startGroup('Cachix: upload');
+  core.startGroup('Cachix: push');
   try {
     if (skipPush === 'true') {
       core.info('Pushing is disabled as skipPush is set to true');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import { execFileSync } from 'child_process';
 import * as coreCommand from '@actions/core/lib/command'
 import * as exec from '@actions/exec';
 
@@ -48,25 +47,23 @@ async function setup() {
     await exec.exec("sh", ["-c", `nix path-info --all | grep -v '\.drv$' > /tmp/store-path-pre-build`]);
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);
-    throw (error);
   }
 }
 
 async function upload() {
+  core.startGroup('Cachix: upload');
   try {
     if (skipPush === 'true') {
       core.info('Pushing is disabled as skipPush is set to true');
     } else if (signingKey !== "" || authToken !== "") {
-      core.startGroup('Cachix: pushing paths');
-      execFileSync(`${__dirname}/push-paths.sh`, [cachixExecutable, name], { stdio: 'inherit' });
-      core.endGroup();
+      await exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name]);
     } else {
       core.info('Pushing is disabled as signing key nor auth token are set.');
     }
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);
-    throw (error);
   }
+  core.endGroup();
 }
 
 // Main


### PR DESCRIPTION
On error, just mark the error with `core.setFailed`, this is enough to
kill the process (apparently).

Replace `child_process.execFileSync` with `'@actions/exec'.exec` to be async
all the way and remove the `UnhandledPromiseRejectionWarning` backtrace.

Before:
![image](https://user-images.githubusercontent.com/3248/103466620-7f100700-4d3e-11eb-97de-e227ee14f2da.png)

After:
![image](https://user-images.githubusercontent.com/3248/103466648-a9fa5b00-4d3e-11eb-8beb-e14751f6601b.png)
