### PR TITLE
Add `pushFilter` to allow filtering cache derivations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,8 @@ inputs:
     description: 'Signing key secret retrieved after creating binary cache on https://cachix.org'
   skipPush:
     description: 'Set to true to disable pushing build results to the cache'
+  pushFilter:
+    description: 'Regular expression to exclude derivations for the cache push, for example "(-source$|nixpkgs\.tar\.gz$)". Warning: this filter doet not guarantee it will not get pushed in case the path is part of the closure of something that will get pushed.'
   installCommand:
     description: 'Override the default cachix installation method'
 branding:

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -1042,6 +1042,7 @@ const extraPullNames = core.getInput('extraPullNames');
 const signingKey = core.getInput('signingKey');
 const authToken = core.getInput('authToken');
 const skipPush = core.getInput('skipPush');
+const pushFilter = core.getInput('pushFilter');
 const cachixExecutable = process.env.HOME + '/.nix-profile/bin/cachix';
 const installCommand = core.getInput('installCommand') ||
     "nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install";
@@ -1086,7 +1087,7 @@ function upload() {
                 core.info('Pushing is disabled as skipPush is set to true');
             }
             else if (signingKey !== "" || authToken !== "") {
-                yield exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name]);
+                yield exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name, pushFilter]);
             }
             else {
                 core.info('Pushing is disabled as signing key nor auth token are set.');

--- a/dist/main/push-paths.sh
+++ b/dist/main/push-paths.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-comm -13 <(sort /tmp/store-path-pre-build) <("$(dirname "$0")"/list-nix-store.sh) | "$1" push -j8 "$2"
+PATHS=$(comm -13 <(sort /tmp/store-path-pre-build) <("$(dirname "$0")"/list-nix-store.sh))
+
+if [[ $3 != "" ]]; then
+    PATHS=$(echo "$PATHS" | grep -vE "$3")
+fi
+
+echo "$PATHS" | "$1" push -j8 "$2"

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ const extraPullNames = core.getInput('extraPullNames');
 const signingKey = core.getInput('signingKey');
 const authToken = core.getInput('authToken')
 const skipPush = core.getInput('skipPush');
+const pushFilter = core.getInput('pushFilter');
 const cachixExecutable = process.env.HOME + '/.nix-profile/bin/cachix';
 const installCommand =
   core.getInput('installCommand') ||
@@ -56,7 +57,7 @@ async function upload() {
     if (skipPush === 'true') {
       core.info('Pushing is disabled as skipPush is set to true');
     } else if (signingKey !== "" || authToken !== "") {
-      await exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name]);
+      await exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name, pushFilter]);
     } else {
       core.info('Pushing is disabled as signing key nor auth token are set.');
     }


### PR DESCRIPTION
This allows filtering derivations to be pushed via an optional
`pushFilter` variable.

The use case behind it is to not push the actually built derivation, but
only runtime and build dependencies.

