### PR TITLE
Allow pushFilter regex to start with a dash

### DIFF
--- a/dist/main/push-paths.sh
+++ b/dist/main/push-paths.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 PATHS=$(comm -13 <(sort /tmp/store-path-pre-build) <("$(dirname "$0")"/list-nix-store.sh))
 
 if [[ $3 != "" ]]; then
-    PATHS=$(echo "$PATHS" | grep -vE "$3")
+    PATHS=$(echo "$PATHS" | grep -vEe "$3")
 fi
 
 echo "$PATHS" | "$1" push -j8 "$2"


### PR DESCRIPTION
For
```yaml
pushFilter: '-(source|nixpkgs-src)$'
```

I got the error
```
grep: invalid option -- '('
```
