### PR TITLE
Add pathsToPush and cachixArgs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,12 @@ inputs:
     description: 'Signing key secret retrieved after creating binary cache on https://cachix.org'
   skipPush:
     description: 'Set to true to disable pushing build results to the cache'
+  pathsToPush:
+    description: 'Whitespace-separated list of paths to push. Leave empty to push every build result.'
   pushFilter:
-    description: 'Regular expression to exclude derivations for the cache push, for example "(-source$|nixpkgs\.tar\.gz$)". Warning: this filter does not guarantee it will not get pushed in case the path is part of the closure of something that will get pushed.'
+    description: 'Ignored if pathsToPush is set. Regular expression to exclude derivations for the cache push, for example "(-source$|nixpkgs\.tar\.gz$)". Warning: this filter does not guarantee it will not get pushed in case the path is part of the closure of something that will get pushed.'
+  cachixArgs:
+    description: 'Extra command-line arguments to pass to cachix. If empty, defaults to -j8'
   installCommand:
     description: 'Override the default cachix installation method'
 branding:

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -1042,8 +1042,10 @@ const extraPullNames = core.getInput('extraPullNames');
 const signingKey = core.getInput('signingKey');
 const authToken = core.getInput('authToken');
 const skipPush = core.getInput('skipPush');
+const pathsToPush = core.getInput('pathsToPush');
 const pushFilter = core.getInput('pushFilter');
 const cachixExecutable = process.env.HOME + '/.nix-profile/bin/cachix';
+const cachixArgs = core.getInput('cachixArgs');
 const installCommand = core.getInput('installCommand') ||
     "nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install";
 function setup() {
@@ -1087,7 +1089,7 @@ function upload() {
                 core.info('Pushing is disabled as skipPush is set to true');
             }
             else if (signingKey !== "" || authToken !== "") {
-                yield exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name, pushFilter]);
+                yield exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, cachixArgs, name, pathsToPush, pushFilter]);
             }
             else {
                 core.info('Pushing is disabled as signingKey nor authToken are set (or are emtpy?) in your YAML file.');

--- a/dist/main/push-paths.sh
+++ b/dist/main/push-paths.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PATHS=$(comm -13 <(sort /tmp/store-path-pre-build) <("$(dirname "$0")"/list-nix-store.sh))
+cachix=$1 cachixArgs=${2:--j8} cache=$3 pathsToPush=$4 pushFilter=$5
 
-if [[ $3 != "" ]]; then
-    PATHS=$(echo "$PATHS" | grep -vEe "$3")
+if [[ $pathsToPush == "" ]]; then
+    pathsToPush=$(comm -13 <(sort /tmp/store-path-pre-build) <("$(dirname "$0")"/list-nix-store.sh))
+
+    if [[ $pushFilter != "" ]]; then
+        pathsToPush=$(echo "$pathsToPush" | grep -vEe "$pushFilter")
+    fi
 fi
 
-echo "$PATHS" | "$1" push -j8 "$2"
+echo "$pathsToPush" | "$cachix" push $cachixArgs "$cache"

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,10 @@ const extraPullNames = core.getInput('extraPullNames');
 const signingKey = core.getInput('signingKey');
 const authToken = core.getInput('authToken')
 const skipPush = core.getInput('skipPush');
+const pathsToPush = core.getInput('pathsToPush');
 const pushFilter = core.getInput('pushFilter');
 const cachixExecutable = process.env.HOME + '/.nix-profile/bin/cachix';
+const cachixArgs = core.getInput('cachixArgs');
 const installCommand =
   core.getInput('installCommand') ||
   "nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install";
@@ -57,7 +59,7 @@ async function upload() {
     if (skipPush === 'true') {
       core.info('Pushing is disabled as skipPush is set to true');
     } else if (signingKey !== "" || authToken !== "") {
-      await exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name, pushFilter]);
+      await exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, cachixArgs, name, pathsToPush, pushFilter]);
     } else {
       core.info('Pushing is disabled as signingKey nor authToken are set (or are emtpy?) in your YAML file.');
     }


### PR DESCRIPTION
Give more control to the user over exactly what is pushed and how.

Fixes https://github.com/cachix/cachix-action/issues/74, fixes https://github.com/cachix/cachix-action/issues/88.

Tested on my repo.