### PR TITLE
Fix minor typo in message

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -1090,7 +1090,7 @@ function upload() {
                 yield exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name, pushFilter]);
             }
             else {
-                core.info('Pushing is disabled as signingKey nor authToken are set (or are emtpy?) in your YAML file.');
+                core.info('Pushing is disabled as signingKey nor authToken are set (or are empty?) in your YAML file.');
             }
         }
         catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ async function upload() {
     } else if (signingKey !== "" || authToken !== "") {
       await exec.exec(`${__dirname}/push-paths.sh`, [cachixExecutable, name, pushFilter]);
     } else {
-      core.info('Pushing is disabled as signingKey nor authToken are set (or are emtpy?) in your YAML file.');
+      core.info('Pushing is disabled as signingKey nor authToken are set (or are empty?) in your YAML file.');
     }
   } catch (error) {
     core.setFailed(`Action failed with error: ${error}`);


### PR DESCRIPTION
Just happened to notice it in my log. `emtpy` → `empty`