### PR TITLE
feat: support node.js 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,6 @@ branding:
   color: 'blue'
   icon: 'database'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/main/index.js'
   post: 'dist/main/index.js'


### PR DESCRIPTION
nodejs 16 supported by runner version 2.285.0

https://github.com/actions/runner/issues/772

Usefull with self hosted runner on nixos with nixos-unstable (with nodejs 16 by default)