### PR TITLE
Use `core.saveState` instead of raw `save-state` command

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4287,7 +4287,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.IsPost = void 0;
 const core = __importStar(__nccwpck_require__(186));
-const coreCommand = __importStar(__nccwpck_require__(351));
 const exec = __importStar(__nccwpck_require__(514));
 const which_1 = __importDefault(__nccwpck_require__(207));
 exports.IsPost = !!process.env['STATE_isPost'];
@@ -4364,7 +4363,7 @@ function upload() {
 if (!exports.IsPost) {
     // Publish a variable so that when the POST action runs, it can determine it should run the cleanup logic.
     // This is necessary since we don't have a separate entry point.
-    coreCommand.issueCommand('save-state', { name: 'isPost' }, 'true');
+    core.saveState('isPost', 'true');
     setup();
 }
 else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import * as core from '@actions/core';
-import * as coreCommand from '@actions/core/lib/command'
 import * as exec from '@actions/exec';
 import which from 'which';
 
@@ -79,7 +78,7 @@ async function upload() {
 if (!IsPost) {
   // Publish a variable so that when the POST action runs, it can determine it should run the cleanup logic.
   // This is necessary since we don't have a separate entry point.
-  coreCommand.issueCommand('save-state', {name: 'isPost'}, 'true')
+  core.saveState('isPost', 'true');
   setup()
 } else {
   // Post


### PR DESCRIPTION
The `save-state` and `set-output` commands are deprecated since 2022-10-11 and cause warnings when used in workflows:

  https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The `saveState` function from `@actions/core` >= 1.10.0 uses the new way to pass data to the post actions (`$GITHUB_STATE`); use that function instead of sending the deprecated `save-state` command directly.

Fixes #125.