### PR TITLE
Add option to avoid calling `cachix use`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ inputs:
     description: 'Extra command-line arguments to pass to cachix. If empty, defaults to -j8'
   installCommand:
     description: 'Override the default cachix installation method'
+  skipAddingSubstituter:
+    description: 'Set to true to skip adding cachix cache as a substitute'
 branding:
   color: 'blue'
   icon: 'database'

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4301,6 +4301,7 @@ const pushFilter = core.getInput('pushFilter');
 const cachixArgs = core.getInput('cachixArgs');
 const installCommand = core.getInput('installCommand') ||
     "nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install";
+const skipAddingSubstituter = core.getInput('skipAddingSubstituter');
 function setup() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -4316,9 +4317,14 @@ function setup() {
             if (authToken !== "") {
                 yield exec.exec('cachix', ['authtoken', authToken]);
             }
-            core.startGroup(`Cachix: using cache ` + name);
-            yield exec.exec('cachix', ['use', name]);
-            core.endGroup();
+            if (skipAddingSubstituter === 'true') {
+                core.info('Not adding Cachix cache to substituters as skipAddingSubstituter is set to true');
+            }
+            else {
+                core.startGroup(`Cachix: using cache ` + name);
+                yield exec.exec('cachix', ['use', name]);
+                core.endGroup();
+            }
             if (extraPullNames != "") {
                 core.startGroup(`Cachix: using extra caches ` + extraPullNames);
                 const extraPullNameList = extraPullNames.split(',');

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ const cachixArgs = core.getInput('cachixArgs');
 const installCommand =
   core.getInput('installCommand') ||
   "nix-env --quiet -j8 -iA cachix -f https://cachix.org/api/v1/install";
+const skipAddingSubstituter = core.getInput('skipAddingSubstituter');
 
 async function setup() {
   try {
@@ -34,9 +35,13 @@ async function setup() {
       await exec.exec('cachix', ['authtoken', authToken]);
     }
 
-    core.startGroup(`Cachix: using cache ` + name);
-    await exec.exec('cachix', ['use', name]);
-    core.endGroup();
+    if (skipAddingSubstituter === 'true') {
+      core.info('Not adding Cachix cache to substituters as skipAddingSubstituter is set to true')
+    } else {
+      core.startGroup(`Cachix: using cache ` + name);
+      await exec.exec('cachix', ['use', name]);
+      core.endGroup();
+    }
 
     if (extraPullNames != "") {
       core.startGroup(`Cachix: using extra caches ` + extraPullNames);


### PR DESCRIPTION
This is particularly useful on self-hosted runners where we can already add the Cachix cache to substituters but don't want to set the runner as a trusted user.

The better fix would've been to update `cachix use` to check if the substituters already contains the binary cache we're about to add, but I'm not too familiar with Haskell so this was the easiest way to fix this issue