### PR TITLE
Pass `cachixArgs` to the daemon

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -7824,6 +7824,7 @@ async function setup() {
                 'daemon', 'run',
                 '--socket', `${daemonDir}/daemon.sock`,
                 name,
+                ...cachixArgs.split(' ').filter((arg) => arg !== ''),
             ], {
                 stdio: ['ignore', daemonLog, daemonLog],
                 detached: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,6 +113,7 @@ async function setup() {
           'daemon', 'run',
           '--socket', `${daemonDir}/daemon.sock`,
           name,
+          ...cachixArgs.split(' ').filter((arg) => arg !== ''),
         ],
         {
           stdio: ['ignore', daemonLog, daemonLog],


### PR DESCRIPTION
Allows passing options, like `--verbose`.