### PR TITLE
Skip prep steps if using `pathsToPush`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,8 +87,7 @@ jobs:
       uses: ./
       with:
         name: cachix-action
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY_PRIVATE }}'
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         pathsToPush: '${{ steps.paths.outputs.OUT_PATHS }}'
 
   installCommand:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,28 @@ jobs:
         useDaemon: ${{ matrix.useDaemon }}
     - run: nix-build test.nix
 
+  push-paths:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - run: yarn install --frozen-lockfile
+    - run: yarn build
+    - uses: cachix/install-nix-action@v26
+    - id: paths
+      run: |
+        paths=$(nix-instantiate test.nix --help | tr '\n' ' ')
+        echo "OUT_PATHS=$paths" >> $GITHUB_OUTPUT
+    - name: Test pushPaths
+      uses: ./
+      with:
+        name: cachix-action-private
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY_PRIVATE }}'
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        pathsToPush: '${{ steps.paths.outputs.OUT_PATHS }}'
+
   installCommand:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,12 +81,12 @@ jobs:
     - uses: cachix/install-nix-action@v26
     - id: paths
       run: |
-        paths=$(nix-instantiate test.nix --help | tr '\n' ' ')
+        paths=$(nix-instantiate test.nix | tr '\n' ' ')
         echo "OUT_PATHS=$paths" >> $GITHUB_OUTPUT
     - name: Test pushPaths
       uses: ./
       with:
-        name: cachix-action-private
+        name: cachix-action
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY_PRIVATE }}'
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         pathsToPush: '${{ steps.paths.outputs.OUT_PATHS }}'

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -7851,7 +7851,7 @@ async function setup() {
                 'daemon', 'run',
                 '--socket', `${daemonDir}/daemon.sock`,
                 name,
-                ...cachixArgs.split(' ').filter((arg) => arg !== ''),
+                ...splitArgs(cachixArgs),
             ], {
                 stdio: ['ignore', daemonLog, daemonLog],
                 detached: true,
@@ -7901,7 +7901,7 @@ async function upload() {
             break;
         }
         case PushMode.PushPaths: {
-            await exec.exec(cachixBin, ["push", ...cachixArgs.split(' '), name, ...pathsToPush.split(' ')]);
+            await exec.exec(cachixBin, ["push", ...splitArgs(cachixArgs), name, ...splitArgs(pathsToPush)]);
             break;
         }
         case PushMode.Daemon: {
@@ -8082,6 +8082,9 @@ function partitionUsersAndGroups(mixedUsers) {
         }
     });
     return [users, groups];
+}
+function splitArgs(args) {
+    return args.split(' ').filter((arg) => arg !== '');
 }
 const isPost = !!core.getState('isPost');
 // Main

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -7901,7 +7901,7 @@ async function upload() {
             break;
         }
         case PushMode.PushPaths: {
-            await exec.exec(cachixBin, ["push", cachixArgs, name, pathsToPush]);
+            await exec.exec(cachixBin, ["push", ...cachixArgs.split(' '), name, ...pathsToPush.split(' ')]);
             break;
         }
         case PushMode.Daemon: {

--- a/dist/main/push-paths.sh
+++ b/dist/main/push-paths.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cachix=$1 cachixArgs=${2:--j8} cache=$3 pathsToPush=$4 pushFilter=$5
+cachix=$1 cachixArgs=${2:--j8} cache=$3 pushFilter=$4
 
 filterPaths() {
   local regex=$1
@@ -12,12 +12,10 @@ filterPaths() {
   done | xargs
 }
 
-if [[ -z $pathsToPush ]]; then
-    pathsToPush=$(comm -13 <(sort /tmp/store-path-pre-build) <("$(dirname "$0")"/list-nix-store.sh))
+pathsToPush=$(comm -13 <(sort /tmp/store-path-pre-build) <("$(dirname "$0")"/list-nix-store.sh))
 
-    if [[ -n $pushFilter ]]; then
-        pathsToPush=$(filterPaths $pushFilter "$pathsToPush")
-    fi
+if [[ -n $pushFilter ]]; then
+    pathsToPush=$(filterPaths $pushFilter "$pathsToPush")
 fi
 
 echo "$pathsToPush" | "$cachix" push $cachixArgs "$cache"

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,7 +142,7 @@ async function setup() {
           'daemon', 'run',
           '--socket', `${daemonDir}/daemon.sock`,
           name,
-          ...cachixArgs.split(' ').filter((arg) => arg !== ''),
+          ...splitArgs(cachixArgs),
         ],
         {
           stdio: ['ignore', daemonLog, daemonLog],
@@ -207,7 +207,7 @@ async function upload() {
     }
 
     case PushMode.PushPaths: {
-      await exec.exec(cachixBin, ["push", ...cachixArgs.split(' '), name, ...pathsToPush.split(' ')]);
+      await exec.exec(cachixBin, ["push", ...splitArgs(cachixArgs), name, ...splitArgs(pathsToPush)]);
       break;
     }
 
@@ -423,6 +423,10 @@ function partitionUsersAndGroups(mixedUsers: string[]): [string[], string[]] {
   });
 
   return [users, groups];
+}
+
+function splitArgs(args: string): string[] {
+  return args.split(' ').filter((arg) => arg !== '');
 }
 
 const isPost = !!core.getState('isPost');

--- a/src/main.ts
+++ b/src/main.ts
@@ -207,7 +207,7 @@ async function upload() {
     }
 
     case PushMode.PushPaths: {
-      await exec.exec(cachixBin, ["push", cachixArgs, name, pathsToPush]);
+      await exec.exec(cachixBin, ["push", ...cachixArgs.split(' '), name, ...pathsToPush.split(' ')]);
       break;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,8 @@ const ENV_CACHIX_DAEMON_DIR = 'CACHIX_DAEMON_DIR';
 enum PushMode {
   // Disable pushing entirely.
   None = 'None',
+  // Push paths provided via the `pathsToPush` input.
+  PushPaths = 'PushPaths',
   // Scans the entire store during the pre- and post-hooks and uploads the difference.
   // This is a very simple method and is likely to work in any environment.
   // There are two downsides:
@@ -107,7 +109,9 @@ async function setup() {
   let pushMode = PushMode.None;
 
   if (hasPushTokens && !skipPush) {
-    if (useDaemon) {
+    if (pathsToPush) {
+      pushMode = PushMode.PushPaths;
+    } else if (useDaemon) {
       let supportsDaemonInterface = (cachixVersion) ? semver.gte(cachixVersion, '1.7.0') : false;
       let supportsPostBuildHook = await isTrustedUser();
 
@@ -169,6 +173,7 @@ async function setup() {
 
       break;
     }
+
     case PushMode.StoreScan: {
       // Remember existing store paths
       await exec.exec("sh", ["-c", `${__dirname}/list-nix-store.sh > /tmp/store-path-pre-build`]);
@@ -200,6 +205,12 @@ async function upload() {
 
       break;
     }
+
+    case PushMode.PushPaths: {
+      await exec.exec(cachixBin, ["push", cachixArgs, name, pathsToPush]);
+      break;
+    }
+
     case PushMode.Daemon: {
       const daemonDir = process.env[ENV_CACHIX_DAEMON_DIR];
 
@@ -233,7 +244,7 @@ async function upload() {
     }
 
     case PushMode.StoreScan: {
-      await exec.exec(`${__dirname}/push-paths.sh`, [cachixBin, cachixArgs, name, pathsToPush, pushFilter]);
+      await exec.exec(`${__dirname}/push-paths.sh`, [cachixBin, cachixArgs, name, pushFilter]);
       break;
     }
   }


### PR DESCRIPTION
Skips launching the daemon or listing the store if we've got a list of paths to push.