### PR TITLE
docs(fix): note that action secrets are unavailable to just prs from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,16 @@ See [action.yml](action.yml) for all options.
 
 Cachix auth token and signing key need special care as they give read and write access to your caches.
 
-[As per GitHub Actions' security model](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#using-encrypted-secrets-in-a-workflow):
+[As per GitHub Actions' security model](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#accessing-your-secrets):
 
-> Anyone with write access to a repository can create, read, and use secrets.
+> You can use and read secrets in a workflow file if you have access to edit the file.
 
-Which means all developers with write/push access can read your secrets and write to your cache. 
+Which means all developers with write/push access can read your secrets and write to your cache.
 
-Pull requests do not have access to secrets so read access to a public binary cache will work,
+Pull requests from forks do not have access to secrets so read access to a public binary cache will work,
 but pushing will be disabled since there is no signing key.
 
-Note that malicious code submitted via a pull request can, once merged into `master`, reveal the tokens. 
-
+Note that malicious code submitted via forked pull request can, once merged into `master`, reveal tokens.
 
 ## Hacking
 


### PR DESCRIPTION
### Summary

👋 This PR adds some nuance to how tokens can be accessed in workflows since PRs might use the secrets if not configured otherwise - forked PRs instead have no access to secrets at all!

### Preview

Some testing [in this PR](https://github.com/zimeg/nur-packages/pull/3) shows [pushes to the cache](https://github.com/zimeg/nur-packages/actions/runs/9707134678/job/26791842807#step:14:28) from the **Post Setup cachix caches** step in the first run:

```
[2024-06-28 03:47:53][Info] Starting Cachix Daemon
...
[2024-06-28 03:48:37][Info] Pushing /nix/store/2x604xn8hs4qlba5ai6k0d4qsvj422p4-etime-1.0.1
[2024-06-28 03:48:40][Info] Pushed /nix/store/2x604xn8hs4qlba5ai6k0d4qsvj422p4-etime-1.0.1
```

I found that the following can be used to [skip pushing cache updates](https://github.com/zimeg/nur-packages/actions/runs/9708149649/job/26794477008) on pull requests if that's preferred too:

```diff
        - name: Setup cachix caches
+         if: github.event_name != 'pull_request'
          uses: cachix/cachix-action@v15
```

Open to updating this with whatever changes! Thank you for a cool cache! 🙏