### PR TITLE
Add a small delay to allow post-build hooks to flush through

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -28935,6 +28935,8 @@ async function upload() {
                 fromBeginning: true,
             });
             daemonLog.on("line", (line) => core.info(line));
+            // Give the Nix daemon/socket some time to flush all the post-build hooks
+            await waitFor(500);
             try {
                 core.debug("Waiting for Cachix daemon to exit...");
                 await exec.exec(cachixBin, [
@@ -28946,7 +28948,7 @@ async function upload() {
             }
             finally {
                 // Wait a bit for the logs to flush through
-                await new Promise((resolve) => setTimeout(resolve, 1000));
+                await waitFor(1000);
                 daemonLog.unwatch();
             }
             break;
@@ -29118,6 +29120,9 @@ function partitionUsersAndGroups(mixedUsers) {
 }
 function splitArgs(args) {
     return args.split(" ").filter((arg) => arg !== "");
+}
+function waitFor(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }
 const isPost = !!core.getState("isPost");
 // Main

--- a/src/main.ts
+++ b/src/main.ts
@@ -261,6 +261,9 @@ async function upload() {
       });
       daemonLog.on("line", (line) => core.info(line));
 
+      // Give the Nix daemon/socket some time to flush all the post-build hooks
+      await waitFor(500);
+
       try {
         core.debug("Waiting for Cachix daemon to exit...");
         await exec.exec(cachixBin, [
@@ -271,7 +274,7 @@ async function upload() {
         ]);
       } finally {
         // Wait a bit for the logs to flush through
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await waitFor(1000);
         daemonLog.unwatch();
       }
 
@@ -488,6 +491,10 @@ function partitionUsersAndGroups(mixedUsers: string[]): [string[], string[]] {
 
 function splitArgs(args: string): string[] {
   return args.split(" ").filter((arg) => arg !== "");
+}
+
+function waitFor(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const isPost = !!core.getState("isPost");


### PR DESCRIPTION
It's sometimes possible for the last built store path to not get picked up by the Cachix daemon. This delay gives the writer (Nix daemon) some time to flush the messages through the socket before we tell our daemon to stop listening for more paths.